### PR TITLE
add dts plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sass": "^1.52.0",
     "typescript": "^4.5.4",
     "vite": "^3.2.3",
+    "vite-plugin-dts": "^1.7.1",
     "vitepress": "^1.0.0-alpha.12",
     "vitest": "0.12.9",
     "vue": "^3.2.25",

--- a/tsconfig.config.json
+++ b/tsconfig.config.json
@@ -8,6 +8,7 @@
   "compilerOptions": {
     "composite": true,
     "types": ["node"],
-    "allowJs": true
+    "allowJs": true,
+    "target": "ES5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "target": "ES5"
   },
 
   "references": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,11 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import dts from 'vite-plugin-dts'
 
 export default defineConfig({
   plugins: [
+    dts(),
     vue({
       reactivityTransform: true
     })


### PR DESCRIPTION
Add vite-plugin-dts, which generates declaration files (*.d.ts) from .ts(x) or .vue source files when using vite in [library mode](https://vitejs.dev/guide/build.html#library-mode).

Set ECMAScript to version 5.

[Github repo vite-plugin-dts](https://github.com/qmhc/vite-plugin-dts)